### PR TITLE
Use environment variables as fallback

### DIFF
--- a/icontrol_install_config.py
+++ b/icontrol_install_config.py
@@ -373,19 +373,15 @@ def main():
     "   "
     module = AnsibleModule(
         argument_spec={
-            'host': {'required': True},
-            'username': {'type': 'str'},
-            'password': {'type': 'str', 'no_log': True},
+            'host': {'required': True, 'fallback': (env_fallback, ['F5_SERVER'])},
+            'username': {'type': 'str', 'fallback': (env_fallback, ['F5_USER'])},
+            'password': {'type': 'str', 'no_log': True, 'fallback': (env_fallback, ['F5_PASSWORD'])},
             'token': {'type': 'str'},
             'uri': {'required': True, 'type': 'str'},
             'body': {'default': {}, 'type': 'raw'},
             'method': {'default': 'POST', 'type': 'str'},
             'debug': {'default': False, 'type': 'bool'}
         },
-        mutually_exclusive=[
-            ['username','token'],
-            ['password','token']
-        ],
         required_together=[
             ['username','password']
         ],


### PR DESCRIPTION
I use the official bigip modules and this module in the same playbook and being able to use the same environment variables is a nice convenience. And since the genericMETHOD functions already decide on which type of auth to use with token the preferred method, un/pw and token don't need to be mutually exclusive. This allows the environment variables to always be defined, but also use token auth.

Let me know what you think.